### PR TITLE
Add Django to installation requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms='any',
+    install_requires=['django'],
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',


### PR DESCRIPTION
While doing a package audit at work I installed just this package locally
```
virtualenv -p python3.7 test-env && source test-env/bin/activate
git clone git@github.com:jacobian/dj-database-url.git
pip install -e dj-database-url/
python -m unittest discover dj-database-url
```

Which failed with:
```
(test-env) shawn@lappy:~/Documents/package_playground$ python -m unittest discover dj-database-url/
E
======================================================================
ERROR: test_dj_database_url (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: test_dj_database_url
Traceback (most recent call last):
  File "/usr/lib/python3.7/unittest/loader.py", line 436, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.7/unittest/loader.py", line 377, in _get_module_from_name
    __import__(name)
  File "/home/shawn/Documents/package_playground/dj-database-url/test_dj_database_url.py", line 7, in <module>
    from django import VERSION as DJANGO_VERSION
ModuleNotFoundError: No module named 'django'
----------------------------------------------------------------------
Ran 1 test in 0.000s

FAILED (errors=1)
```

After making the change to `setup.py` and re-installing the package locally the tests pass via unittest.